### PR TITLE
Optimize release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 members = ["crates/inspect-core", "crates/inspect-cli", "crates/inspect-mcp", "crates/inspect-api"]
 resolver = "2"
+
+[profile.release]
+strip = "symbols"
+lto = true
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
The artifacts in the latest release are quite large (~40 MB) I think mostly due to not stripping debug symbols. I also took the liberty to configure other commonly used options for releases.