### PR TITLE
Handle LLM review coverage gaps

### DIFF
--- a/crates/inspect-cli/src/commands/review.rs
+++ b/crates/inspect-cli/src/commands/review.rs
@@ -1,3 +1,4 @@
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 use clap::Args;
@@ -6,7 +7,10 @@ use sem_core::git::types::DiffScope;
 
 use crate::OutputFormat;
 use inspect_core::analyze::analyze;
-use inspect_core::llm::{AnthropicClient, OpenAIClient, LlmProvider, EntityLlmReview, LlmVerdict};
+use inspect_core::llm::{
+    estimate_entity_input_tokens, AnthropicClient, EntityLlmReview, LlmProvider, LlmReviewOptions,
+    LlmReviewStatus, LlmVerdict, OpenAIClient,
+};
 use inspect_core::types::RiskLevel;
 
 #[derive(Args)]
@@ -57,25 +61,44 @@ pub struct ReviewArgs {
     /// Timeout in seconds for remote review polling (default: 120)
     #[arg(long, default_value = "120")]
     pub timeout: u64,
+
+    /// Maximum estimated input tokens per entity prompt before skipping
+    #[arg(long, default_value = "120000")]
+    pub max_input_tokens: u64,
+
+    /// Retries for 429/rate-limit API responses
+    #[arg(long, default_value = "3")]
+    pub max_retries: u32,
 }
 
 fn build_provider(args: &ReviewArgs) -> Result<Box<dyn LlmProvider>, String> {
     // Infer provider: explicit flag > api-base implies openai > default anthropic
-    let provider = args
-        .provider
-        .as_deref()
-        .unwrap_or_else(|| if args.api_base.is_some() { "openai" } else { "anthropic" });
+    let provider = args.provider.as_deref().unwrap_or_else(|| {
+        if args.api_base.is_some() {
+            "openai"
+        } else {
+            "anthropic"
+        }
+    });
+
+    let options = LlmReviewOptions {
+        max_input_tokens: args.max_input_tokens,
+        max_retries: args.max_retries,
+        ..LlmReviewOptions::default()
+    };
 
     match provider {
         "anthropic" => {
-            let client = AnthropicClient::new(&args.model, args.api_key.as_deref())?;
+            let client =
+                AnthropicClient::new_with_options(&args.model, args.api_key.as_deref(), options)?;
             Ok(Box::new(client))
         }
         "openai" => {
-            let client = OpenAIClient::new(
+            let client = OpenAIClient::new_with_options(
                 &args.model,
                 args.api_base.as_deref(),
                 args.api_key.as_deref(),
+                options,
             )?;
             Ok(Box::new(client))
         }
@@ -84,7 +107,7 @@ fn build_provider(args: &ReviewArgs) -> Result<Box<dyn LlmProvider>, String> {
                 .api_base
                 .as_deref()
                 .unwrap_or("http://localhost:11434/v1");
-            let client = OpenAIClient::new(&args.model, Some(base), None)?;
+            let client = OpenAIClient::new_with_options(&args.model, Some(base), None, options)?;
             Ok(Box::new(client))
         }
         other => Err(format!(
@@ -143,6 +166,7 @@ pub async fn run(args: ReviewArgs) {
     };
 
     let mut reviews: Vec<EntityLlmReview> = Vec::new();
+    let mut degraded_entities: Vec<String> = Vec::new();
 
     for (i, entity) in result.entity_reviews.iter().enumerate() {
         eprint!(
@@ -154,11 +178,20 @@ pub async fn run(args: ReviewArgs) {
 
         match client.review_entity(entity).await {
             Ok(review) => {
-                eprintln!("{}", format_verdict_inline(review.verdict));
+                eprintln!("{}", format_review_inline(&review));
+                if entity.risk_level >= RiskLevel::High && !review.is_reviewed() {
+                    degraded_entities.push(entity.entity_name.clone());
+                }
                 reviews.push(review);
             }
             Err(e) => {
-                eprintln!("{}", format!("error: {}", e).red());
+                eprintln!("{}", format!("failed: {}", e).red().bold());
+                let review =
+                    EntityLlmReview::failed(entity, e, estimate_entity_input_tokens(entity));
+                if entity.risk_level >= RiskLevel::High {
+                    degraded_entities.push(entity.entity_name.clone());
+                }
+                reviews.push(review);
             }
         }
     }
@@ -167,6 +200,40 @@ pub async fn run(args: ReviewArgs) {
         OutputFormat::Terminal => print_terminal(&reviews),
         OutputFormat::Json => print_json(&reviews),
         OutputFormat::Markdown => print_markdown(&reviews),
+    }
+
+    if !degraded_entities.is_empty() {
+        flush_stdout_before_exit();
+        eprintln!(
+            "{}",
+            format!(
+                "error: review degraded: {} high-risk entit{} not reviewed ({})",
+                degraded_entities.len(),
+                if degraded_entities.len() == 1 {
+                    "y was"
+                } else {
+                    "ies were"
+                },
+                degraded_entities.join(", ")
+            )
+            .red()
+        );
+        std::process::exit(2);
+    }
+}
+
+fn flush_stdout_before_exit() {
+    if let Err(e) = io::stdout().flush() {
+        eprintln!("{}", format!("error: failed to flush stdout: {}", e).red());
+        std::process::exit(1);
+    }
+}
+
+fn format_review_inline(review: &EntityLlmReview) -> String {
+    match review.status {
+        LlmReviewStatus::Reviewed => format_verdict_inline(review.verdict),
+        LlmReviewStatus::Skipped => "skipped".yellow().to_string(),
+        LlmReviewStatus::Failed => "failed".red().bold().to_string(),
     }
 }
 
@@ -183,24 +250,30 @@ fn print_terminal(reviews: &[EntityLlmReview]) {
         return;
     }
 
-    let total_tokens: u64 = reviews.iter().map(|r| r.tokens_used).sum();
+    let summary = summarize_reviews(reviews);
+    let total_tokens: u64 = reviews
+        .iter()
+        .filter(|r| r.is_reviewed())
+        .map(|r| r.tokens_used)
+        .sum();
     let changes_requested = reviews
         .iter()
-        .filter(|r| r.verdict == LlmVerdict::RequestChanges)
+        .filter(|r| r.is_reviewed() && r.verdict == LlmVerdict::RequestChanges)
         .count();
     let comments = reviews
         .iter()
-        .filter(|r| r.verdict == LlmVerdict::Comment)
+        .filter(|r| r.is_reviewed() && r.verdict == LlmVerdict::Comment)
         .count();
     let approved = reviews
         .iter()
-        .filter(|r| r.verdict == LlmVerdict::Approve)
+        .filter(|r| r.is_reviewed() && r.verdict == LlmVerdict::Approve)
         .count();
 
     println!(
-        "\n{} {} entities reviewed ({} tokens)",
+        "\n{} {}/{} entities reviewed ({} tokens)",
         "review".bold().cyan(),
-        reviews.len(),
+        summary.reviewed,
+        summary.total,
         total_tokens,
     );
     println!(
@@ -209,15 +282,16 @@ fn print_terminal(reviews: &[EntityLlmReview]) {
         format!("{}", comments).yellow(),
         format!("{}", changes_requested).red(),
     );
+    if summary.failed > 0 || summary.skipped > 0 {
+        println!(
+            "  {} failed, {} skipped",
+            format!("{}", summary.failed).red(),
+            format!("{}", summary.skipped).yellow(),
+        );
+    }
 
     for review in reviews {
-        let badge = match review.verdict {
-            LlmVerdict::Approve => " APPROVE ".on_green().white().bold().to_string(),
-            LlmVerdict::Comment => " COMMENT ".on_yellow().black().bold().to_string(),
-            LlmVerdict::RequestChanges => {
-                " CHANGES ".on_red().white().bold().to_string()
-            }
-        };
+        let badge = format_review_badge(review);
 
         println!(
             "\n  {} {} {}",
@@ -230,17 +304,35 @@ fn print_terminal(reviews: &[EntityLlmReview]) {
             println!("    {}", review.summary);
         }
 
-        for issue in &review.issues {
-            let sev = match issue.severity.as_str() {
-                "error" => "error".red().bold().to_string(),
-                "warning" => "warning".yellow().to_string(),
-                _ => "info".dimmed().to_string(),
-            };
-            println!("    [{}] {}", sev, issue.description);
+        if let Some(reason) = &review.failure_reason {
+            println!("    {}", reason);
+        }
+
+        if review.is_reviewed() {
+            for issue in &review.issues {
+                let sev = match issue.severity.as_str() {
+                    "error" => "error".red().bold().to_string(),
+                    "warning" => "warning".yellow().to_string(),
+                    _ => "info".dimmed().to_string(),
+                };
+                println!("    [{}] {}", sev, issue.description);
+            }
         }
     }
 
     println!();
+}
+
+fn format_review_badge(review: &EntityLlmReview) -> String {
+    match review.status {
+        LlmReviewStatus::Reviewed => match review.verdict {
+            LlmVerdict::Approve => " APPROVE ".on_green().white().bold().to_string(),
+            LlmVerdict::Comment => " COMMENT ".on_yellow().black().bold().to_string(),
+            LlmVerdict::RequestChanges => " CHANGES ".on_red().white().bold().to_string(),
+        },
+        LlmReviewStatus::Skipped => " SKIPPED ".on_yellow().black().bold().to_string(),
+        LlmReviewStatus::Failed => " FAILED ".on_red().white().bold().to_string(),
+    }
 }
 
 fn print_json(reviews: &[EntityLlmReview]) {
@@ -250,33 +342,34 @@ fn print_json(reviews: &[EntityLlmReview]) {
 fn print_markdown(reviews: &[EntityLlmReview]) {
     println!("# Code Review\n");
 
+    let summary = summarize_reviews(reviews);
     let changes_requested = reviews
         .iter()
-        .filter(|r| r.verdict == LlmVerdict::RequestChanges)
+        .filter(|r| r.is_reviewed() && r.verdict == LlmVerdict::RequestChanges)
         .count();
     let comments = reviews
         .iter()
-        .filter(|r| r.verdict == LlmVerdict::Comment)
+        .filter(|r| r.is_reviewed() && r.verdict == LlmVerdict::Comment)
         .count();
     let approved = reviews
         .iter()
-        .filter(|r| r.verdict == LlmVerdict::Approve)
+        .filter(|r| r.is_reviewed() && r.verdict == LlmVerdict::Approve)
         .count();
 
     println!(
-        "{} entities reviewed: {} approved, {} comments, {} changes requested\n",
-        reviews.len(),
-        approved,
-        comments,
-        changes_requested,
+        "{}/{} entities reviewed: {} approved, {} comments, {} changes requested\n",
+        summary.reviewed, summary.total, approved, comments, changes_requested,
     );
 
+    if summary.failed > 0 || summary.skipped > 0 {
+        println!(
+            "**Coverage gaps:** {} failed, {} skipped\n",
+            summary.failed, summary.skipped
+        );
+    }
+
     for review in reviews {
-        let verdict_str = match review.verdict {
-            LlmVerdict::Approve => "Approve",
-            LlmVerdict::Comment => "Comment",
-            LlmVerdict::RequestChanges => "Changes Requested",
-        };
+        let verdict_str = format_markdown_status(review);
 
         println!(
             "## {} `{}` ({})\n",
@@ -287,12 +380,55 @@ fn print_markdown(reviews: &[EntityLlmReview]) {
             println!("{}\n", review.summary);
         }
 
-        for issue in &review.issues {
-            println!("- **{}**: {}", issue.severity, issue.description);
+        if let Some(reason) = &review.failure_reason {
+            println!("**Reason:** {}\n", reason);
+        }
+
+        if review.is_reviewed() {
+            for issue in &review.issues {
+                println!("- **{}**: {}", issue.severity, issue.description);
+            }
         }
 
         println!();
     }
+}
+
+fn format_markdown_status(review: &EntityLlmReview) -> &'static str {
+    match review.status {
+        LlmReviewStatus::Reviewed => match review.verdict {
+            LlmVerdict::Approve => "Approve",
+            LlmVerdict::Comment => "Comment",
+            LlmVerdict::RequestChanges => "Changes Requested",
+        },
+        LlmReviewStatus::Skipped => "Skipped",
+        LlmReviewStatus::Failed => "Failed",
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ReviewSummary {
+    total: usize,
+    reviewed: usize,
+    failed: usize,
+    skipped: usize,
+}
+
+fn summarize_reviews(reviews: &[EntityLlmReview]) -> ReviewSummary {
+    let mut summary = ReviewSummary {
+        total: reviews.len(),
+        ..ReviewSummary::default()
+    };
+
+    for review in reviews {
+        match review.status {
+            LlmReviewStatus::Reviewed => summary.reviewed += 1,
+            LlmReviewStatus::Failed => summary.failed += 1,
+            LlmReviewStatus::Skipped => summary.skipped += 1,
+        }
+    }
+
+    summary
 }
 
 async fn run_remote(args: ReviewArgs) {
@@ -300,7 +436,10 @@ async fn run_remote(args: ReviewArgs) {
     let pr_number: u64 = match args.target.parse() {
         Ok(n) => n,
         Err(_) => {
-            eprintln!("{}", "error: target must be a PR number when using --remote".red());
+            eprintln!(
+                "{}",
+                "error: target must be a PR number when using --remote".red()
+            );
             std::process::exit(1);
         }
     };
@@ -359,7 +498,10 @@ async fn run_remote(args: ReviewArgs) {
 
     loop {
         if std::time::Instant::now() > deadline {
-            eprintln!("{}", format!("error: timed out after {}s", args.timeout).red());
+            eprintln!(
+                "{}",
+                format!("error: timed out after {}s", args.timeout).red()
+            );
             std::process::exit(1);
         }
 
@@ -434,7 +576,9 @@ fn print_remote_result(args: &ReviewArgs, job: &serde_json::Value) {
                     let description = f["description"].as_str().unwrap_or("");
                     let file = f["file"].as_str().unwrap_or("");
                     let sev_colored = match severity {
-                        "error" | "critical" | "high" => format!("[{}]", severity).red().to_string(),
+                        "error" | "critical" | "high" => {
+                            format!("[{}]", severity).red().to_string()
+                        }
                         "warning" | "medium" => format!("[{}]", severity).yellow().to_string(),
                         _ => format!("[{}]", severity).dimmed().to_string(),
                     };
@@ -475,5 +619,58 @@ fn parse_risk_level(s: &str) -> RiskLevel {
         "high" => RiskLevel::High,
         "medium" => RiskLevel::Medium,
         _ => RiskLevel::Low,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use inspect_core::llm::LlmIssue;
+
+    fn llm_review(status: LlmReviewStatus, verdict: LlmVerdict) -> EntityLlmReview {
+        EntityLlmReview {
+            entity_name: "handle".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            status,
+            verdict,
+            issues: vec![LlmIssue {
+                severity: "info".to_string(),
+                description: "detail".to_string(),
+            }],
+            summary: "summary".to_string(),
+            tokens_used: 10,
+            estimated_input_tokens: 20,
+            failure_reason: None,
+        }
+    }
+
+    #[test]
+    fn summary_counts_reviewed_failed_and_skipped_separately() {
+        let reviews = vec![
+            llm_review(LlmReviewStatus::Reviewed, LlmVerdict::Approve),
+            llm_review(LlmReviewStatus::Failed, LlmVerdict::Comment),
+            llm_review(LlmReviewStatus::Skipped, LlmVerdict::Comment),
+        ];
+
+        assert_eq!(
+            summarize_reviews(&reviews),
+            ReviewSummary {
+                total: 3,
+                reviewed: 1,
+                failed: 1,
+                skipped: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn markdown_status_uses_review_status_before_verdict() {
+        let failed = llm_review(LlmReviewStatus::Failed, LlmVerdict::Approve);
+        let skipped = llm_review(LlmReviewStatus::Skipped, LlmVerdict::RequestChanges);
+        let reviewed = llm_review(LlmReviewStatus::Reviewed, LlmVerdict::RequestChanges);
+
+        assert_eq!(format_markdown_status(&failed), "Failed");
+        assert_eq!(format_markdown_status(&skipped), "Skipped");
+        assert_eq!(format_markdown_status(&reviewed), "Changes Requested");
     }
 }

--- a/crates/inspect-core/src/llm.rs
+++ b/crates/inspect-core/src/llm.rs
@@ -1,16 +1,125 @@
 use async_trait::async_trait;
+use reqwest::header::{HeaderValue, RETRY_AFTER};
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 use crate::types::EntityReview;
+
+const DEFAULT_MAX_INPUT_TOKENS: u64 = 120_000;
+const DEFAULT_MAX_RETRIES: u32 = 3;
+const DEFAULT_INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
+const DEFAULT_MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+const APPROX_CHARS_PER_TOKEN: u64 = 4;
+
+#[derive(Debug, Clone)]
+pub struct LlmReviewOptions {
+    pub max_input_tokens: u64,
+    pub max_retries: u32,
+    pub initial_retry_delay: Duration,
+    pub max_retry_delay: Duration,
+}
+
+impl Default for LlmReviewOptions {
+    fn default() -> Self {
+        Self {
+            max_input_tokens: DEFAULT_MAX_INPUT_TOKENS,
+            max_retries: DEFAULT_MAX_RETRIES,
+            initial_retry_delay: DEFAULT_INITIAL_RETRY_DELAY,
+            max_retry_delay: DEFAULT_MAX_RETRY_DELAY,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmReviewStatus {
+    Reviewed,
+    Skipped,
+    Failed,
+}
+
+impl Default for LlmReviewStatus {
+    fn default() -> Self {
+        Self::Reviewed
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntityLlmReview {
     pub entity_name: String,
     pub file_path: String,
+    #[serde(default)]
+    pub status: LlmReviewStatus,
     pub verdict: LlmVerdict,
     pub issues: Vec<LlmIssue>,
     pub summary: String,
     pub tokens_used: u64,
+    #[serde(default)]
+    pub estimated_input_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
+}
+
+impl EntityLlmReview {
+    pub fn skipped(
+        entity: &EntityReview,
+        reason: impl Into<String>,
+        estimated_input_tokens: u64,
+    ) -> Self {
+        Self::unreviewed(
+            entity,
+            LlmReviewStatus::Skipped,
+            "warning",
+            "LLM review skipped",
+            reason,
+            estimated_input_tokens,
+        )
+    }
+
+    pub fn failed(
+        entity: &EntityReview,
+        reason: impl Into<String>,
+        estimated_input_tokens: u64,
+    ) -> Self {
+        Self::unreviewed(
+            entity,
+            LlmReviewStatus::Failed,
+            "error",
+            "LLM review failed",
+            reason,
+            estimated_input_tokens,
+        )
+    }
+
+    pub fn is_reviewed(&self) -> bool {
+        self.status == LlmReviewStatus::Reviewed
+    }
+
+    fn unreviewed(
+        entity: &EntityReview,
+        status: LlmReviewStatus,
+        severity: &str,
+        summary: &str,
+        reason: impl Into<String>,
+        estimated_input_tokens: u64,
+    ) -> Self {
+        let reason = reason.into();
+        Self {
+            entity_name: entity.entity_name.clone(),
+            file_path: entity.file_path.clone(),
+            status,
+            verdict: LlmVerdict::Comment,
+            issues: vec![LlmIssue {
+                severity: severity.to_string(),
+                description: reason.clone(),
+            }],
+            summary: summary.to_string(),
+            tokens_used: 0,
+            estimated_input_tokens,
+            failure_reason: Some(reason),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -117,7 +226,11 @@ struct LlmOutput {
     summary: String,
 }
 
-fn parse_llm_output(text: &str, entity: &EntityReview, tokens: u64) -> EntityLlmReview {
+fn parse_llm_output(
+    text: &str,
+    entity: &EntityReview,
+    tokens: u64,
+) -> Result<EntityLlmReview, String> {
     let json_str = text
         .trim()
         .strip_prefix("```json")
@@ -126,23 +239,29 @@ fn parse_llm_output(text: &str, entity: &EntityReview, tokens: u64) -> EntityLlm
         .unwrap_or(text)
         .trim();
 
-    let output: LlmOutput = serde_json::from_str(json_str).unwrap_or(LlmOutput {
-        verdict: LlmVerdict::Comment,
-        issues: vec![LlmIssue {
-            severity: "info".to_string(),
-            description: text.to_string(),
-        }],
-        summary: "Could not parse structured response".to_string(),
-    });
+    if json_str.is_empty() {
+        return Err("LLM response was empty".to_string());
+    }
 
-    EntityLlmReview {
+    let output: LlmOutput = serde_json::from_str(json_str).map_err(|e| {
+        format!(
+            "Failed to parse structured LLM response: {}; response: {}",
+            e,
+            truncate_for_error(text)
+        )
+    })?;
+
+    Ok(EntityLlmReview {
         entity_name: entity.entity_name.clone(),
         file_path: entity.file_path.clone(),
+        status: LlmReviewStatus::Reviewed,
         verdict: output.verdict,
         issues: output.issues,
         summary: output.summary,
         tokens_used: tokens,
-    }
+        estimated_input_tokens: estimate_entity_input_tokens(entity),
+        failure_reason: None,
+    })
 }
 
 // --- AnthropicClient ---
@@ -151,19 +270,33 @@ pub struct AnthropicClient {
     client: reqwest::Client,
     api_key: String,
     model: String,
+    options: LlmReviewOptions,
 }
 
 impl AnthropicClient {
     pub fn new(model: &str, api_key: Option<&str>) -> Result<Self, String> {
+        Self::new_with_options(model, api_key, LlmReviewOptions::default())
+    }
+
+    pub fn new_with_options(
+        model: &str,
+        api_key: Option<&str>,
+        options: LlmReviewOptions,
+    ) -> Result<Self, String> {
         let api_key = api_key
             .map(|k| k.to_string())
-            .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.is_empty()))
+            .or_else(|| {
+                std::env::var("ANTHROPIC_API_KEY")
+                    .ok()
+                    .filter(|k| !k.is_empty())
+            })
             .ok_or_else(|| "ANTHROPIC_API_KEY not set. Set it to use LLM review.".to_string())?;
 
         Ok(Self {
             client: reqwest::Client::new(),
             api_key,
             model: model.to_string(),
+            options,
         })
     }
 }
@@ -172,6 +305,18 @@ impl AnthropicClient {
 impl LlmProvider for AnthropicClient {
     async fn review_entity(&self, entity: &EntityReview) -> Result<EntityLlmReview, String> {
         let prompt = build_prompt(entity);
+        let estimated_input_tokens = estimate_request_input_tokens(&prompt);
+
+        if estimated_input_tokens > self.options.max_input_tokens {
+            return Ok(EntityLlmReview::skipped(
+                entity,
+                format!(
+                    "estimated prompt size {} tokens exceeds max input budget {}",
+                    estimated_input_tokens, self.options.max_input_tokens
+                ),
+                estimated_input_tokens,
+            ));
+        }
 
         let request = AnthropicRequest {
             model: self.model.clone(),
@@ -183,22 +328,15 @@ impl LlmProvider for AnthropicClient {
             }],
         };
 
-        let resp = self
-            .client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| format!("API request failed: {}", e))?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("API error {}: {}", status, body));
-        }
+        let resp = send_with_retries(&self.options, || {
+            self.client
+                .post("https://api.anthropic.com/v1/messages")
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", "2023-06-01")
+                .header("content-type", "application/json")
+                .json(&request)
+        })
+        .await?;
 
         let api_resp: AnthropicResponse = resp
             .json()
@@ -213,7 +351,7 @@ impl LlmProvider for AnthropicClient {
 
         let tokens = api_resp.usage.input_tokens + api_resp.usage.output_tokens;
 
-        Ok(parse_llm_output(text, entity, tokens))
+        parse_llm_output(text, entity, tokens)
     }
 }
 
@@ -224,13 +362,25 @@ pub struct OpenAIClient {
     api_key: Option<String>,
     api_base: String,
     model: String,
+    options: LlmReviewOptions,
 }
 
 impl OpenAIClient {
     pub fn new(model: &str, api_base: Option<&str>, api_key: Option<&str>) -> Result<Self, String> {
-        let api_key = api_key
-            .map(|k| k.to_string())
-            .or_else(|| std::env::var("OPENAI_API_KEY").ok().filter(|k| !k.is_empty()));
+        Self::new_with_options(model, api_base, api_key, LlmReviewOptions::default())
+    }
+
+    pub fn new_with_options(
+        model: &str,
+        api_base: Option<&str>,
+        api_key: Option<&str>,
+        options: LlmReviewOptions,
+    ) -> Result<Self, String> {
+        let api_key = api_key.map(|k| k.to_string()).or_else(|| {
+            std::env::var("OPENAI_API_KEY")
+                .ok()
+                .filter(|k| !k.is_empty())
+        });
 
         let api_base = api_base
             .map(|s| s.trim_end_matches('/').to_string())
@@ -241,6 +391,7 @@ impl OpenAIClient {
             api_key,
             api_base,
             model: model.to_string(),
+            options,
         })
     }
 }
@@ -249,6 +400,18 @@ impl OpenAIClient {
 impl LlmProvider for OpenAIClient {
     async fn review_entity(&self, entity: &EntityReview) -> Result<EntityLlmReview, String> {
         let prompt = build_prompt(entity);
+        let estimated_input_tokens = estimate_request_input_tokens(&prompt);
+
+        if estimated_input_tokens > self.options.max_input_tokens {
+            return Ok(EntityLlmReview::skipped(
+                entity,
+                format!(
+                    "estimated prompt size {} tokens exceeds max input budget {}",
+                    estimated_input_tokens, self.options.max_input_tokens
+                ),
+                estimated_input_tokens,
+            ));
+        }
 
         let request = OpenAIRequest {
             model: self.model.clone(),
@@ -267,26 +430,19 @@ impl LlmProvider for OpenAIClient {
 
         let url = format!("{}/chat/completions", self.api_base);
 
-        let mut req = self
-            .client
-            .post(&url)
-            .header("content-type", "application/json");
+        let resp = send_with_retries(&self.options, || {
+            let mut req = self
+                .client
+                .post(&url)
+                .header("content-type", "application/json");
 
-        if let Some(ref key) = self.api_key {
-            req = req.header("authorization", format!("Bearer {}", key));
-        }
+            if let Some(ref key) = self.api_key {
+                req = req.header("authorization", format!("Bearer {}", key));
+            }
 
-        let resp = req
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| format!("API request failed: {}", e))?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("API error {}: {}", status, body));
-        }
+            req.json(&request)
+        })
+        .await?;
 
         let api_resp: OpenAIResponse = resp
             .json()
@@ -304,11 +460,104 @@ impl LlmProvider for OpenAIClient {
             .map(|u| u.prompt_tokens + u.completion_tokens)
             .unwrap_or(0);
 
-        Ok(parse_llm_output(text, entity, tokens))
+        parse_llm_output(text, entity, tokens)
     }
 }
 
 // --- Shared helpers ---
+
+async fn send_with_retries<F>(
+    options: &LlmReviewOptions,
+    mut build_request: F,
+) -> Result<reqwest::Response, String>
+where
+    F: FnMut() -> reqwest::RequestBuilder,
+{
+    let mut retries = 0;
+
+    loop {
+        let resp = build_request()
+            .send()
+            .await
+            .map_err(|e| format!("API request failed: {}", e))?;
+
+        if resp.status().is_success() {
+            return Ok(resp);
+        }
+
+        let status = resp.status();
+        let retry_after =
+            retry_after_delay(resp.headers().get(RETRY_AFTER), options.max_retry_delay);
+        let body = resp.text().await.unwrap_or_default();
+
+        if !is_retryable_api_error(status, &body) || retries >= options.max_retries {
+            let attempts = retries + 1;
+            return Err(format!(
+                "API error {} after {} attempt{}: {}",
+                status,
+                attempts,
+                if attempts == 1 { "" } else { "s" },
+                body
+            ));
+        }
+
+        let delay = retry_after.unwrap_or_else(|| backoff_delay(options, retries));
+        retries += 1;
+        tokio::time::sleep(delay).await;
+    }
+}
+
+fn is_retryable_api_error(status: StatusCode, body: &str) -> bool {
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        return true;
+    }
+
+    let body = body.to_ascii_lowercase();
+    body.contains("rate limit") || body.contains("too many requests")
+}
+
+fn retry_after_delay(value: Option<&HeaderValue>, max_delay: Duration) -> Option<Duration> {
+    let seconds = value?.to_str().ok()?.trim().parse::<u64>().ok()?;
+    Some(Duration::from_secs(seconds).min(max_delay))
+}
+
+fn backoff_delay(options: &LlmReviewOptions, retry_number: u32) -> Duration {
+    let factor = 1_u128 << retry_number.min(10);
+    let millis = options
+        .initial_retry_delay
+        .as_millis()
+        .saturating_mul(factor)
+        .min(options.max_retry_delay.as_millis());
+
+    Duration::from_millis(millis as u64)
+}
+
+pub fn estimate_entity_input_tokens(entity: &EntityReview) -> u64 {
+    let prompt = build_prompt(entity);
+    estimate_request_input_tokens(&prompt)
+}
+
+fn estimate_request_input_tokens(prompt: &str) -> u64 {
+    estimate_tokens(SYSTEM_PROMPT) + estimate_tokens(prompt)
+}
+
+pub fn estimate_tokens(text: &str) -> u64 {
+    let chars = text.chars().count() as u64;
+    if chars == 0 {
+        0
+    } else {
+        (chars + APPROX_CHARS_PER_TOKEN - 1) / APPROX_CHARS_PER_TOKEN
+    }
+}
+
+fn truncate_for_error(text: &str) -> String {
+    const MAX_CHARS: usize = 500;
+    let mut output: String = text.chars().take(MAX_CHARS).collect();
+    if text.chars().count() > MAX_CHARS {
+        output.push_str("...");
+    }
+    output
+}
 
 const SYSTEM_PROMPT: &str = "\
 You are a code reviewer. Review the entity for bugs, security issues, and correctness problems. \
@@ -321,8 +570,14 @@ fn build_prompt(entity: &EntityReview) -> String {
         format!("File: {}", entity.file_path),
         format!("Change: {:?}", entity.change_type),
         format!("Classification: {}", entity.classification),
-        format!("Risk: {} (score {:.2})", entity.risk_level, entity.risk_score),
-        format!("Blast radius: {}, Dependents: {}", entity.blast_radius, entity.dependent_count),
+        format!(
+            "Risk: {} (score {:.2})",
+            entity.risk_level, entity.risk_score
+        ),
+        format!(
+            "Blast radius: {}, Dependents: {}",
+            entity.blast_radius, entity.dependent_count
+        ),
     ];
 
     if entity.is_public_api {
@@ -348,4 +603,226 @@ fn build_prompt(entity: &EntityReview) -> String {
     }
 
     parts.join("\n\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ChangeClassification, RiskLevel};
+    use sem_core::model::change::ChangeType;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn make_review(after_content: &str) -> EntityReview {
+        EntityReview {
+            entity_id: "src/lib.rs::function::handle".to_string(),
+            entity_name: "handle".to_string(),
+            entity_type: "function".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            change_type: ChangeType::Modified,
+            classification: ChangeClassification::Functional,
+            risk_score: 0.8,
+            risk_level: RiskLevel::High,
+            blast_radius: 0,
+            dependent_count: 0,
+            dependency_count: 0,
+            is_public_api: false,
+            structural_change: Some(true),
+            group_id: 0,
+            start_line: 1,
+            end_line: 3,
+            before_content: None,
+            after_content: Some(after_content.to_string()),
+            dependent_names: vec![],
+            dependency_names: vec![],
+            dependent_entities: vec![],
+        }
+    }
+
+    #[test]
+    fn estimates_tokens_by_rounding_up_character_count() {
+        assert_eq!(estimate_tokens(""), 0);
+        assert_eq!(estimate_tokens("abc"), 1);
+        assert_eq!(estimate_tokens("abcd"), 1);
+        assert_eq!(estimate_tokens("abcde"), 2);
+    }
+
+    #[test]
+    fn retry_after_delay_uses_delta_seconds() {
+        let value = HeaderValue::from_static("7");
+        assert_eq!(
+            retry_after_delay(Some(&value), Duration::from_secs(30)),
+            Some(Duration::from_secs(7))
+        );
+    }
+
+    #[test]
+    fn retry_after_delay_is_capped_by_options() {
+        let value = HeaderValue::from_static("3600");
+        assert_eq!(
+            retry_after_delay(Some(&value), Duration::from_secs(30)),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn retryable_errors_include_rate_limit_signals() {
+        assert!(is_retryable_api_error(StatusCode::TOO_MANY_REQUESTS, ""));
+        assert!(is_retryable_api_error(
+            StatusCode::BAD_REQUEST,
+            "provider rate limit exceeded"
+        ));
+        assert!(!is_retryable_api_error(StatusCode::BAD_REQUEST, "bad json"));
+    }
+
+    #[tokio::test]
+    async fn skips_entity_when_estimate_exceeds_budget() {
+        let entity = make_review("pub fn handle() { println!(\"too large\"); }");
+        let client = OpenAIClient::new_with_options(
+            "test-model",
+            Some("http://127.0.0.1:1/v1"),
+            None,
+            LlmReviewOptions {
+                max_input_tokens: 1,
+                max_retries: 0,
+                initial_retry_delay: Duration::from_millis(1),
+                max_retry_delay: Duration::from_millis(1),
+            },
+        )
+        .unwrap();
+
+        let review = client.review_entity(&entity).await.unwrap();
+
+        assert_eq!(review.status, LlmReviewStatus::Skipped);
+        assert_eq!(review.tokens_used, 0);
+        assert!(review
+            .failure_reason
+            .as_deref()
+            .unwrap()
+            .contains("estimated prompt size"));
+    }
+
+    #[test]
+    fn failed_records_preserve_entity_identity_and_reason() {
+        let entity = make_review("pub fn handle() {}");
+        let review = EntityLlmReview::failed(&entity, "API error 429", 42);
+
+        assert_eq!(review.status, LlmReviewStatus::Failed);
+        assert_eq!(review.entity_name, "handle");
+        assert_eq!(review.file_path, "src/lib.rs");
+        assert_eq!(review.estimated_input_tokens, 42);
+        assert_eq!(review.failure_reason.as_deref(), Some("API error 429"));
+    }
+
+    #[test]
+    fn malformed_llm_response_is_an_error() {
+        let entity = make_review("pub fn handle() {}");
+        let err = parse_llm_output("not json", &entity, 12).unwrap_err();
+
+        assert!(err.contains("Failed to parse structured LLM response"));
+    }
+
+    #[tokio::test]
+    async fn openai_client_retries_rate_limits_then_returns_review() {
+        let (base_url, request_count) = spawn_openai_test_server(vec![
+            "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 10\r\nContent-Length: 19\r\n\r\nrate limit exceeded"
+                .to_string(),
+            openai_success_response(),
+        ])
+        .await;
+        let entity = make_review("pub fn handle() {}");
+        let client = OpenAIClient::new_with_options(
+            "test-model",
+            Some(&base_url),
+            None,
+            LlmReviewOptions {
+                max_input_tokens: 10_000,
+                max_retries: 1,
+                initial_retry_delay: Duration::from_millis(1),
+                max_retry_delay: Duration::from_millis(1),
+            },
+        )
+        .unwrap();
+
+        let review = client.review_entity(&entity).await.unwrap();
+
+        assert_eq!(request_count.load(Ordering::SeqCst), 2);
+        assert_eq!(review.status, LlmReviewStatus::Reviewed);
+        assert_eq!(review.verdict, LlmVerdict::Approve);
+    }
+
+    #[tokio::test]
+    async fn openai_client_returns_error_after_retry_budget() {
+        let (base_url, request_count) = spawn_openai_test_server(vec![
+            "HTTP/1.1 429 Too Many Requests\r\nContent-Length: 19\r\n\r\nrate limit exceeded"
+                .to_string(),
+            "HTTP/1.1 429 Too Many Requests\r\nContent-Length: 19\r\n\r\nrate limit exceeded"
+                .to_string(),
+        ])
+        .await;
+        let entity = make_review("pub fn handle() {}");
+        let client = OpenAIClient::new_with_options(
+            "test-model",
+            Some(&base_url),
+            None,
+            LlmReviewOptions {
+                max_input_tokens: 10_000,
+                max_retries: 1,
+                initial_retry_delay: Duration::from_millis(1),
+                max_retry_delay: Duration::from_millis(1),
+            },
+        )
+        .unwrap();
+
+        let err = client.review_entity(&entity).await.unwrap_err();
+
+        assert_eq!(request_count.load(Ordering::SeqCst), 2);
+        assert!(err.contains("after 2 attempts"));
+    }
+
+    async fn spawn_openai_test_server(responses: Vec<String>) -> (String, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let count = Arc::clone(&request_count);
+
+        tokio::spawn(async move {
+            for response in responses {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                count.fetch_add(1, Ordering::SeqCst);
+
+                let mut buf = vec![0_u8; 4096];
+                let _ = stream.read(&mut buf).await.unwrap();
+                stream.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        (format!("http://{}", addr), request_count)
+    }
+
+    fn openai_success_response() -> String {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "{\"verdict\":\"approve\",\"issues\":[],\"summary\":\"ok\"}"
+                }
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 2
+            }
+        })
+        .to_string();
+
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- add per-entity reviewed/skipped/failed status for local `inspect review` output
- preflight estimated prompt tokens and skip prompts above the configured input budget
- retry rate-limit responses with exponential backoff and capped `Retry-After` delays
- degrade high-risk reviews with failed/skipped entities and preserve records in terminal, JSON, and Markdown output

Closes #14

## Test plan

- `cargo test -p inspect-core llm`
- `cargo test -p inspect-cli review::tests`
- `cargo test --workspace`
- `cargo run -p inspect-cli -- review HEAD --provider openai --api-base http://127.0.0.1:1 --api-key dummy --max-input-tokens 1 --max-entities 1 --min-risk low --format json`
- `cargo run -p inspect-cli -- review HEAD --provider openai --api-base http://127.0.0.1:1 --api-key dummy --max-input-tokens 1 --max-entities 1 --min-risk low --format terminal`
- `cargo run -p inspect-cli -- review HEAD --provider openai --api-base http://127.0.0.1:1 --api-key dummy --max-input-tokens 1 --max-entities 1 --min-risk low --format markdown`