### PR TITLE
Include review prompt context for helpers and file windows

### DIFF
--- a/crates/inspect-cli/src/commands/review.rs
+++ b/crates/inspect-cli/src/commands/review.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 use sem_core::git::types::DiffScope;
 
 use crate::OutputFormat;
-use inspect_core::analyze::analyze;
+use inspect_core::analyze::{analyze_with_options, AnalyzeOptions};
 use inspect_core::llm::{
     estimate_entity_input_tokens, AnthropicClient, EntityLlmReview, LlmProvider, LlmReviewOptions,
     LlmReviewStatus, LlmVerdict, OpenAIClient,
@@ -125,7 +125,14 @@ pub async fn run(args: ReviewArgs) {
     let scope = parse_scope(&args.target);
     let repo = args.repo.canonicalize().unwrap_or(args.repo.clone());
 
-    let mut result = match analyze(&repo, scope) {
+    let options = AnalyzeOptions {
+        include_dependent_code: true,
+        include_dependency_code: true,
+        include_file_context: true,
+        ..AnalyzeOptions::default()
+    };
+
+    let mut result = match analyze_with_options(&repo, scope, &options) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: {}", e);

--- a/crates/inspect-core/src/analyze.rs
+++ b/crates/inspect-core/src/analyze.rs
@@ -1,14 +1,13 @@
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use git2::{ObjectType, Repository, Tree};
 use sem_core::git::bridge::GitBridge;
 use sem_core::git::types::{DiffScope, FileChange, FileStatus};
 use sem_core::model::change::ChangeType;
 use sem_core::parser::differ::compute_semantic_diff;
-use sem_core::parser::graph::EntityGraph;
+use sem_core::parser::graph::{EntityGraph, EntityInfo};
 use sem_core::parser::plugins::create_default_registry;
-use tempfile::TempDir;
+use sem_core::parser::registry::ParserRegistry;
 
 use crate::classify::classify_change;
 use crate::github::FilePair;
@@ -21,18 +20,33 @@ use crate::untangle::untangle;
 pub struct AnalyzeOptions {
     /// Include full source code of dependent entities (callers/consumers).
     pub include_dependent_code: bool,
+    /// Include full source code of dependency entities (callees/helpers).
+    pub include_dependency_code: bool,
+    /// Include a small source window around each changed entity.
+    pub include_file_context: bool,
     /// Maximum number of dependents to include per changed entity.
     pub max_dependents_per_entity: usize,
+    /// Maximum number of dependencies to include per changed entity.
+    pub max_dependencies_per_entity: usize,
     /// Skip dependent entities larger than this many lines.
     pub max_dependent_lines: usize,
+    /// Skip dependency entities larger than this many lines.
+    pub max_dependency_lines: usize,
+    /// Number of lines to include before and after the changed entity.
+    pub file_context_lines: usize,
 }
 
 impl Default for AnalyzeOptions {
     fn default() -> Self {
         Self {
             include_dependent_code: false,
+            include_dependency_code: false,
+            include_file_context: false,
             max_dependents_per_entity: 5,
+            max_dependencies_per_entity: 5,
             max_dependent_lines: 100,
+            max_dependency_lines: 100,
+            file_context_lines: 8,
         }
     }
 }
@@ -41,10 +55,12 @@ impl Default for AnalyzeOptions {
 /// Used by both analyze and predict.
 pub(crate) struct AnalysisContext {
     pub graph: EntityGraph,
-    pub source_root: std::path::PathBuf,
-    _source_tree: Option<TempDir>,
+    pub before_graph: Option<EntityGraph>,
     pub changes: Vec<sem_core::model::change::SemanticChange>,
+    pub file_changes: HashMap<String, FileChange>,
     pub changed_entity_ids: HashSet<String>,
+    pub after_source: ContentSource,
+    pub before_source: Option<ContentSource>,
     pub total_graph_entities: usize,
     pub diff_ms: u64,
     pub list_files_ms: u64,
@@ -52,16 +68,26 @@ pub(crate) struct AnalysisContext {
     pub graph_build_ms: u64,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum ContentSource {
+    Worktree,
+    Index,
+    GitRef(String),
+}
+
 /// Run Phases 1-3: entity diff, file listing, graph build.
 /// Returns None if there are no changes.
 pub(crate) fn build_context(
     repo_path: &Path,
     scope: DiffScope,
+    include_before_graph: bool,
 ) -> Result<Option<AnalysisContext>, AnalyzeError> {
     use std::time::Instant;
 
     let git = GitBridge::open(repo_path).map_err(|e| AnalyzeError::Git(e.to_string()))?;
     let registry = create_default_registry();
+    let after_source = after_source_for_scope(&scope);
+    let before_source = before_source_for_scope(&scope);
 
     let file_changes: Vec<FileChange> = git
         .get_changed_files(&scope, &[])
@@ -74,6 +100,11 @@ pub(crate) fn build_context(
         return Ok(None);
     }
 
+    let file_change_map: HashMap<String, FileChange> = file_changes
+        .iter()
+        .map(|f| (f.file_path.clone(), f.clone()))
+        .collect();
+
     // Phase 1: Compute entity-level diff
     let diff_start = Instant::now();
     let diff = compute_semantic_diff(&file_changes, &registry, None, None);
@@ -83,10 +114,9 @@ pub(crate) fn build_context(
         return Ok(None);
     }
 
-    // Phase 2: List all source files in the graph source tree
+    // Phase 2: List all source files in the reviewed after-side tree
     let list_start = Instant::now();
-    let graph_source = graph_source_for_scope(git.repo_root(), &scope)?;
-    let all_files = graph_source.files;
+    let all_files = list_source_files_from_source(repo_path, &after_source)?;
     let file_count = all_files.len();
     let list_files_ms = list_start.elapsed().as_millis() as u64;
 
@@ -95,16 +125,35 @@ pub(crate) fn build_context(
 
     // Phase 3: Build entity graph from ALL source files (parallel via rayon)
     let graph_start = Instant::now();
-    let (graph, _all_entities) = EntityGraph::build(&graph_source.root, &all_files, &registry);
+    let (graph, _all_entities) = build_graph_for_source(
+        repo_path,
+        git.repo_root(),
+        &after_source,
+        &all_files,
+        &registry,
+    )?;
     let graph_build_ms = graph_start.elapsed().as_millis() as u64;
     let total_graph_entities = graph.entities.len();
 
+    let before_graph = if include_before_graph {
+        before_source.as_ref().and_then(|source| {
+            let files = list_source_files_from_source(repo_path, source).ok()?;
+            build_graph_for_source(repo_path, git.repo_root(), source, &files, &registry)
+                .ok()
+                .map(|(graph, _)| graph)
+        })
+    } else {
+        None
+    };
+
     Ok(Some(AnalysisContext {
         graph,
-        source_root: graph_source.root,
-        _source_tree: graph_source.temp_dir,
+        before_graph,
         changes: diff.changes,
+        file_changes: file_change_map,
         changed_entity_ids,
+        after_source,
+        before_source,
         total_graph_entities,
         diff_ms,
         list_files_ms,
@@ -128,22 +177,24 @@ pub fn analyze_with_options(
 
     let total_start = Instant::now();
 
-    let ctx = match build_context(repo_path, scope)? {
+    let ctx = match build_context(repo_path, scope, options.include_dependency_code)? {
         Some(ctx) => ctx,
         None => return Ok(empty_result()),
     };
 
     let AnalysisContext {
         graph,
+        before_graph,
         changes,
+        file_changes,
         changed_entity_ids,
+        after_source,
+        before_source,
         total_graph_entities,
         diff_ms,
         list_files_ms,
         file_count,
         graph_build_ms,
-        source_root,
-        _source_tree,
     } = ctx;
 
     // Phase 4: Score, classify, untangle
@@ -151,31 +202,100 @@ pub fn analyze_with_options(
 
     let mut reviews: Vec<EntityReview> = Vec::new();
     let mut dependency_edges: Vec<(String, String)> = Vec::new();
+    let mut before_entity_ids: HashMap<String, String> = HashMap::new();
 
     for change in &changes {
+        let before_entity_id = before_graph
+            .as_ref()
+            .and_then(|g| resolve_before_entity_id(change, g));
+        if let Some(ref before_entity_id) = before_entity_id {
+            before_entity_ids.insert(change.entity_id.clone(), before_entity_id.clone());
+        }
+
         let dependents = graph.get_dependents(&change.entity_id);
         let dependencies = graph.get_dependencies(&change.entity_id);
+        let before_dependents = before_graph
+            .as_ref()
+            .zip(before_entity_id.as_deref())
+            .map(|(g, id)| g.get_dependents(id))
+            .unwrap_or_default();
+        let before_dependencies = before_graph
+            .as_ref()
+            .zip(before_entity_id.as_deref())
+            .map(|(g, id)| g.get_dependencies(id))
+            .unwrap_or_default();
         // Use capped impact count to avoid full BFS on hub entities
-        let blast_radius = graph.impact_count(&change.entity_id, 10_000);
+        let after_blast_radius = graph.impact_count(&change.entity_id, 10_000);
+        let before_blast_radius = before_graph
+            .as_ref()
+            .zip(before_entity_id.as_deref())
+            .map(|(g, id)| g.impact_count(id, 10_000))
+            .unwrap_or(0);
+        let blast_radius = after_blast_radius.max(before_blast_radius);
 
         let classification = classify_change(change);
         let after_content_ref = change.after_content.as_deref();
         let pub_api = is_public_api(&change.entity_type, &change.entity_name, after_content_ref);
 
-        let (start_line, end_line) = graph
+        let after_span = graph
             .entities
             .get(&change.entity_id)
-            .map(|e| (e.start_line, e.end_line))
-            .unwrap_or((0, 0));
+            .map(|e| (e.start_line, e.end_line));
+        let before_span = before_graph
+            .as_ref()
+            .and_then(|g| {
+                before_entity_id
+                    .as_deref()
+                    .and_then(|id| g.entities.get(id))
+            })
+            .map(|e| (e.start_line, e.end_line));
+        let (start_line, end_line) = after_span.or(before_span).unwrap_or((0, 0));
 
-        let dependent_names: Vec<(String, String)> = dependents
-            .iter()
-            .map(|e| (e.name.clone(), e.file_path.clone()))
-            .collect();
-        let dependency_names: Vec<(String, String)> = dependencies
-            .iter()
-            .map(|e| (e.name.clone(), e.file_path.clone()))
-            .collect();
+        let dependent_names = related_names(&dependents, &before_dependents);
+        let dependency_names = related_names(&dependencies, &before_dependencies);
+        let file_change = file_changes.get(&change.file_path);
+
+        let (before_start, before_end) = context_span(
+            before_span.map(|span| span.0).unwrap_or(0),
+            before_span.map(|span| span.1).unwrap_or(0),
+            change.entity_line,
+            change.before_content.as_deref(),
+        );
+        let (after_start, after_end) = context_span(
+            after_span.map(|span| span.0).unwrap_or(0),
+            after_span.map(|span| span.1).unwrap_or(0),
+            change.entity_line,
+            change.after_content.as_deref(),
+        );
+
+        let before_file_context = if options.include_file_context {
+            file_change.and_then(|f| {
+                let path = f.old_file_path.as_deref().unwrap_or(&change.file_path);
+                extract_source_context(
+                    f.before_content.as_deref(),
+                    path,
+                    before_start,
+                    before_end,
+                    options.file_context_lines,
+                )
+            })
+        } else {
+            None
+        };
+
+        let after_file_context = if options.include_file_context {
+            file_change.and_then(|f| {
+                extract_source_context(
+                    f.after_content.as_deref(),
+                    &change.file_path,
+                    after_start,
+                    after_end,
+                    options.file_context_lines,
+                )
+            })
+        } else {
+            None
+        };
 
         let mut review = EntityReview {
             entity_id: change.entity_id.clone(),
@@ -187,8 +307,8 @@ pub fn analyze_with_options(
             risk_score: 0.0,
             risk_level: RiskLevel::Low,
             blast_radius,
-            dependent_count: dependents.len(),
-            dependency_count: dependencies.len(),
+            dependent_count: dependent_names.len(),
+            dependency_count: dependency_names.len(),
             is_public_api: pub_api,
             structural_change: change.structural_change,
             group_id: 0,
@@ -199,17 +319,20 @@ pub fn analyze_with_options(
             dependent_names,
             dependency_names,
             dependent_entities: vec![],
+            dependency_entities: vec![],
+            before_file_context,
+            after_file_context,
         };
 
         review.risk_score = compute_risk_score(&review, total_graph_entities);
         review.risk_level = score_to_level(review.risk_score);
 
-        for dep in &dependencies {
+        for dep in dependencies.iter().chain(before_dependencies.iter()) {
             if changed_entity_ids.contains(&dep.id) {
                 dependency_edges.push((change.entity_id.clone(), dep.id.clone()));
             }
         }
-        for dep in &dependents {
+        for dep in dependents.iter().chain(before_dependents.iter()) {
             if changed_entity_ids.contains(&dep.id) {
                 dependency_edges.push((change.entity_id.clone(), dep.id.clone()));
             }
@@ -221,8 +344,31 @@ pub fn analyze_with_options(
     // Phase 4b: Collect dependent entity code if requested
     if options.include_dependent_code {
         for review in &mut reviews {
-            review.dependent_entities =
-                collect_dependent_code(&graph, &review.entity_id, &source_root, options);
+            review.dependent_entities = collect_dependent_code(
+                &graph,
+                before_graph.as_ref(),
+                before_entity_ids.get(&review.entity_id).map(String::as_str),
+                &review.entity_id,
+                repo_path,
+                &after_source,
+                before_source.as_ref(),
+                options,
+            );
+        }
+    }
+
+    if options.include_dependency_code {
+        for review in &mut reviews {
+            review.dependency_entities = collect_dependency_code(
+                &graph,
+                before_graph.as_ref(),
+                before_entity_ids.get(&review.entity_id).map(String::as_str),
+                &review.entity_id,
+                repo_path,
+                &after_source,
+                before_source.as_ref(),
+                options,
+            );
         }
     }
 
@@ -339,6 +485,9 @@ pub fn analyze_remote(file_pairs: &[FilePair]) -> Result<ReviewResult, AnalyzeEr
             dependent_names: vec![],
             dependency_names: vec![],
             dependent_entities: vec![],
+            dependency_entities: vec![],
+            before_file_context: None,
+            after_file_context: None,
         };
 
         review.risk_score = compute_risk_score(&review, 0);
@@ -483,12 +632,93 @@ fn refresh_result_summaries(result: &mut ReviewResult) {
 /// Uses the entity graph to get precise function boundaries via tree-sitter.
 fn collect_dependent_code(
     graph: &EntityGraph,
+    before_graph: Option<&EntityGraph>,
+    before_entity_id: Option<&str>,
     entity_id: &str,
-    source_root: &Path,
+    repo_path: &Path,
+    after_source: &ContentSource,
+    before_source: Option<&ContentSource>,
     options: &AnalyzeOptions,
 ) -> Vec<DependentEntity> {
-    let dependents = graph.get_dependents(entity_id);
-    if dependents.is_empty() {
+    let mut related = collect_related_entity_code(
+        graph,
+        entity_id,
+        graph.get_dependents(entity_id),
+        repo_path,
+        after_source,
+        "after",
+        options.max_dependents_per_entity,
+        options.max_dependent_lines,
+    );
+
+    if let (Some(before_graph), Some(before_source)) = (before_graph, before_source) {
+        let before_entity_id = before_entity_id.unwrap_or(entity_id);
+        related.extend(collect_related_entity_code(
+            before_graph,
+            before_entity_id,
+            before_graph.get_dependents(before_entity_id),
+            repo_path,
+            before_source,
+            "before",
+            options.max_dependents_per_entity,
+            options.max_dependent_lines,
+        ));
+    }
+
+    merge_related_entities(related)
+}
+
+/// Collect full source code of the top dependency entities for a changed entity.
+/// Dependencies are direct callees/helpers referenced by the changed entity.
+fn collect_dependency_code(
+    graph: &EntityGraph,
+    before_graph: Option<&EntityGraph>,
+    before_entity_id: Option<&str>,
+    entity_id: &str,
+    repo_path: &Path,
+    after_source: &ContentSource,
+    before_source: Option<&ContentSource>,
+    options: &AnalyzeOptions,
+) -> Vec<DependentEntity> {
+    let mut related = collect_related_entity_code(
+        graph,
+        entity_id,
+        graph.get_dependencies(entity_id),
+        repo_path,
+        after_source,
+        "after",
+        options.max_dependencies_per_entity,
+        options.max_dependency_lines,
+    );
+
+    if let (Some(before_graph), Some(before_source)) = (before_graph, before_source) {
+        let before_entity_id = before_entity_id.unwrap_or(entity_id);
+        related.extend(collect_related_entity_code(
+            before_graph,
+            before_entity_id,
+            before_graph.get_dependencies(before_entity_id),
+            repo_path,
+            before_source,
+            "before",
+            options.max_dependencies_per_entity,
+            options.max_dependency_lines,
+        ));
+    }
+
+    merge_related_entities(related)
+}
+
+fn collect_related_entity_code(
+    graph: &EntityGraph,
+    entity_id: &str,
+    related_entities: Vec<&EntityInfo>,
+    repo_path: &Path,
+    source: &ContentSource,
+    relation: &str,
+    max_entities: usize,
+    max_lines: usize,
+) -> Vec<DependentEntity> {
+    if related_entities.is_empty() {
         return vec![];
     }
 
@@ -498,14 +728,12 @@ fn collect_dependent_code(
         .map(|e| e.file_path.as_str())
         .unwrap_or("");
 
-    // Score and rank dependents
-    let mut scored: Vec<(&sem_core::parser::graph::EntityInfo, f64)> = dependents
-        .iter()
+    let mut scored: Vec<(&EntityInfo, f64)> = related_entities
+        .into_iter()
         .map(|dep| {
             let own_dep_count = graph.get_dependents(&dep.id).len();
-            let content_hint = std::fs::read_to_string(source_root.join(&dep.file_path))
-                .ok()
-                .and_then(|c| {
+            let content_hint =
+                read_file_from_source(repo_path, source, &dep.file_path).and_then(|c| {
                     let lines: Vec<&str> = c.lines().collect();
                     lines
                         .get(dep.start_line.saturating_sub(1))
@@ -514,22 +742,22 @@ fn collect_dependent_code(
             let is_pub = is_public_api(&dep.entity_type, &dep.name, content_hint.as_deref());
             let is_cross_file = dep.file_path != source_file;
             let score = rank_dependent(own_dep_count, is_pub, is_cross_file);
-            (*dep, score)
+            (dep, score)
         })
         .collect();
 
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-    scored.truncate(options.max_dependents_per_entity);
+    scored.truncate(max_entities);
 
     scored
         .into_iter()
         .filter_map(|(dep, _score)| {
             let line_count = dep.end_line.saturating_sub(dep.start_line) + 1;
-            if line_count > options.max_dependent_lines {
+            if line_count > max_lines {
                 return None;
             }
 
-            let file_content = std::fs::read_to_string(source_root.join(&dep.file_path)).ok()?;
+            let file_content = read_file_from_source(repo_path, source, &dep.file_path)?;
             let lines: Vec<&str> = file_content.lines().collect();
             let start = dep.start_line.saturating_sub(1);
             let end = dep.end_line.min(lines.len());
@@ -551,133 +779,261 @@ fn collect_dependent_code(
                 content,
                 own_dependent_count: own_dep_count,
                 is_public_api: is_pub,
+                relation: Some(relation.to_string()),
             })
         })
         .collect()
 }
 
-struct GraphSource {
-    root: std::path::PathBuf,
-    files: Vec<String>,
-    temp_dir: Option<TempDir>,
+fn merge_related_entities(entities: Vec<DependentEntity>) -> Vec<DependentEntity> {
+    let mut merged: Vec<DependentEntity> = Vec::new();
+
+    'outer: for entity in entities {
+        for existing in &mut merged {
+            if existing.entity_name == entity.entity_name
+                && existing.entity_type == entity.entity_type
+                && existing.file_path == entity.file_path
+                && existing.content == entity.content
+            {
+                if existing.relation != entity.relation {
+                    existing.relation = Some("before_after".to_string());
+                }
+                continue 'outer;
+            }
+        }
+        merged.push(entity);
+    }
+
+    merged
 }
 
-fn graph_source_for_scope(
-    repo_root: &Path,
-    scope: &DiffScope,
-) -> Result<GraphSource, AnalyzeError> {
+fn related_names(
+    after_entities: &[&EntityInfo],
+    before_entities: &[&EntityInfo],
+) -> Vec<(String, String)> {
+    let mut names = Vec::new();
+    let mut seen = HashSet::new();
+
+    for entity in after_entities.iter().chain(before_entities.iter()) {
+        let key = (entity.name.clone(), entity.file_path.clone());
+        if seen.insert(key.clone()) {
+            names.push(key);
+        }
+    }
+
+    names
+}
+
+fn resolve_before_entity_id(
+    change: &sem_core::model::change::SemanticChange,
+    before_graph: &EntityGraph,
+) -> Option<String> {
+    if before_graph.entities.contains_key(&change.entity_id) {
+        return Some(change.entity_id.clone());
+    }
+
+    let before_name = change
+        .old_entity_name
+        .as_deref()
+        .unwrap_or(&change.entity_name);
+    let before_file = change.old_file_path.as_deref().unwrap_or(&change.file_path);
+
+    before_graph
+        .entities
+        .values()
+        .find(|entity| {
+            entity.name == before_name
+                && entity.file_path == before_file
+                && entity.entity_type == change.entity_type
+        })
+        .map(|entity| entity.id.clone())
+}
+
+fn context_span(
+    start_line: usize,
+    end_line: usize,
+    fallback_line: usize,
+    entity_content: Option<&str>,
+) -> (usize, usize) {
+    let start = if start_line > 0 {
+        start_line
+    } else if fallback_line > 0 {
+        fallback_line
+    } else {
+        1
+    };
+
+    let content_lines = entity_content
+        .map(|c| c.lines().count().max(1))
+        .unwrap_or(1);
+    let end = if end_line >= start {
+        end_line
+    } else {
+        start + content_lines - 1
+    };
+
+    (start, end)
+}
+
+fn extract_source_context(
+    file_content: Option<&str>,
+    file_path: &str,
+    entity_start_line: usize,
+    entity_end_line: usize,
+    context_lines: usize,
+) -> Option<SourceContext> {
+    let lines: Vec<&str> = file_content?.lines().collect();
+    if lines.is_empty() {
+        return None;
+    }
+
+    let anchor_start = entity_start_line.max(1).min(lines.len());
+    let anchor_end = entity_end_line.max(anchor_start).min(lines.len());
+    let window_start = anchor_start.saturating_sub(context_lines).max(1);
+    let window_end = (anchor_end + context_lines).min(lines.len());
+
+    let content = (window_start..=window_end)
+        .map(|line_no| format!("{:>4}: {}", line_no, lines[line_no - 1]))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(SourceContext {
+        file_path: file_path.to_string(),
+        start_line: window_start,
+        end_line: window_end,
+        content,
+    })
+}
+
+fn after_source_for_scope(scope: &DiffScope) -> ContentSource {
     match scope {
-        DiffScope::Commit { sha } => materialize_tree_source(repo_root, sha),
-        DiffScope::Range { to, .. } => materialize_tree_source(repo_root, to),
-        DiffScope::Staged => materialize_index_source(repo_root),
-        DiffScope::Working | DiffScope::RefToWorking { .. } => {
-            let files = list_source_files(repo_root)?;
-            Ok(GraphSource {
-                root: repo_root.to_path_buf(),
-                files,
-                temp_dir: None,
-            })
+        DiffScope::Commit { sha } => ContentSource::GitRef(sha.clone()),
+        DiffScope::Range { to, .. } => ContentSource::GitRef(to.clone()),
+        DiffScope::Staged => ContentSource::Index,
+        DiffScope::Working | DiffScope::RefToWorking { .. } => ContentSource::Worktree,
+    }
+}
+
+fn before_source_for_scope(scope: &DiffScope) -> Option<ContentSource> {
+    match scope {
+        DiffScope::Commit { sha } => Some(ContentSource::GitRef(format!("{sha}~1"))),
+        DiffScope::Range { from, .. } => Some(ContentSource::GitRef(from.clone())),
+        DiffScope::RefToWorking { refspec } => Some(ContentSource::GitRef(refspec.clone())),
+        DiffScope::Working | DiffScope::Staged => Some(ContentSource::GitRef("HEAD".to_string())),
+    }
+}
+
+fn build_graph_for_source(
+    repo_path: &Path,
+    worktree_root: &Path,
+    source: &ContentSource,
+    files: &[String],
+    registry: &ParserRegistry,
+) -> Result<(EntityGraph, usize), AnalyzeError> {
+    match source {
+        ContentSource::Worktree => {
+            let (graph, entities) = EntityGraph::build(worktree_root, files, registry);
+            Ok((graph, entities.len()))
+        }
+        ContentSource::Index | ContentSource::GitRef(_) => {
+            let snapshot = materialize_source_tree(repo_path, source, files)?;
+            let (graph, entities) = EntityGraph::build(&snapshot, files, registry);
+            let _ = std::fs::remove_dir_all(snapshot);
+            Ok((graph, entities.len()))
         }
     }
 }
 
-fn materialize_index_source(repo_root: &Path) -> Result<GraphSource, AnalyzeError> {
-    let repo = Repository::discover(repo_root).map_err(|e| AnalyzeError::Git(e.to_string()))?;
-    let index = repo.index().map_err(|e| AnalyzeError::Git(e.to_string()))?;
-    let temp_dir = TempDir::new().map_err(|e| AnalyzeError::Io(e.to_string()))?;
-    let mut files = Vec::new();
+fn materialize_source_tree(
+    repo_path: &Path,
+    source: &ContentSource,
+    files: &[String],
+) -> Result<PathBuf, AnalyzeError> {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let snapshot =
+        std::env::temp_dir().join(format!("inspect-graph-{}-{nanos}", std::process::id()));
+    std::fs::create_dir_all(&snapshot)
+        .map_err(|e| AnalyzeError::Git(format!("failed to create graph snapshot: {e}")))?;
 
-    for entry in index.iter() {
-        let Ok(path) = std::str::from_utf8(&entry.path) else {
-            continue;
+    for file in files {
+        let content = match read_file_from_source(repo_path, source, file) {
+            Some(content) => content,
+            None => continue,
         };
-        if !is_source_file(path) {
+        let path = snapshot.join(file);
+        if !path.starts_with(&snapshot) {
             continue;
         }
-
-        let blob = repo
-            .find_blob(entry.id)
-            .map_err(|e| AnalyzeError::Git(e.to_string()))?;
-        write_source_blob(temp_dir.path(), path, blob.content(), &mut files)?;
-    }
-
-    Ok(GraphSource {
-        root: temp_dir.path().to_path_buf(),
-        files,
-        temp_dir: Some(temp_dir),
-    })
-}
-
-fn materialize_tree_source(repo_root: &Path, refspec: &str) -> Result<GraphSource, AnalyzeError> {
-    let repo = Repository::discover(repo_root).map_err(|e| AnalyzeError::Git(e.to_string()))?;
-    let object = repo
-        .revparse_single(refspec)
-        .map_err(|e| AnalyzeError::Git(e.to_string()))?;
-    let tree = object
-        .peel_to_tree()
-        .map_err(|e| AnalyzeError::Git(e.to_string()))?;
-    let temp_dir = TempDir::new().map_err(|e| AnalyzeError::Io(e.to_string()))?;
-    let mut files = Vec::new();
-
-    materialize_source_files(&repo, &tree, "", temp_dir.path(), &mut files)?;
-
-    Ok(GraphSource {
-        root: temp_dir.path().to_path_buf(),
-        files,
-        temp_dir: Some(temp_dir),
-    })
-}
-
-fn materialize_source_files(
-    repo: &Repository,
-    tree: &Tree<'_>,
-    prefix: &str,
-    target_root: &Path,
-    files: &mut Vec<String>,
-) -> Result<(), AnalyzeError> {
-    for entry in tree.iter() {
-        let name = entry
-            .name()
-            .ok_or_else(|| AnalyzeError::Git("tree entry is not valid UTF-8".into()))?;
-        let path = if prefix.is_empty() {
-            name.to_string()
-        } else {
-            format!("{prefix}/{name}")
-        };
-
-        match entry.kind() {
-            Some(ObjectType::Tree) => {
-                let subtree = repo
-                    .find_tree(entry.id())
-                    .map_err(|e| AnalyzeError::Git(e.to_string()))?;
-                materialize_source_files(repo, &subtree, &path, target_root, files)?;
-            }
-            Some(ObjectType::Blob) if is_source_file(&path) => {
-                let blob = repo
-                    .find_blob(entry.id())
-                    .map_err(|e| AnalyzeError::Git(e.to_string()))?;
-                write_source_blob(target_root, &path, blob.content(), files)?;
-            }
-            _ => {}
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                AnalyzeError::Git(format!("failed to create graph snapshot directory: {e}"))
+            })?;
         }
+        std::fs::write(path, content)
+            .map_err(|e| AnalyzeError::Git(format!("failed to write graph snapshot: {e}")))?;
     }
 
-    Ok(())
+    Ok(snapshot)
 }
 
-fn write_source_blob(
-    target_root: &Path,
-    path: &str,
-    content: &[u8],
-    files: &mut Vec<String>,
-) -> Result<(), AnalyzeError> {
-    let target_path = target_root.join(path);
-    if let Some(parent) = target_path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| AnalyzeError::Io(e.to_string()))?;
+pub(crate) fn read_file_from_source(
+    repo_path: &Path,
+    source: &ContentSource,
+    file_path: &str,
+) -> Option<String> {
+    match source {
+        ContentSource::Worktree => std::fs::read_to_string(repo_path.join(file_path))
+            .ok()
+            .map(normalize_line_endings),
+        ContentSource::Index => git_show_index(repo_path, file_path),
+        ContentSource::GitRef(refspec) => git_show(repo_path, refspec, file_path),
     }
-    std::fs::write(&target_path, content).map_err(|e| AnalyzeError::Io(e.to_string()))?;
-    files.push(path.to_string());
-    Ok(())
+}
+
+fn git_show_index(repo_path: &Path, file_path: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["show", &format!(":{file_path}")])
+        .current_dir(repo_path)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(normalize_line_endings)
+}
+
+fn git_show(repo_path: &Path, refspec: &str, file_path: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["show", &format!("{refspec}:{file_path}")])
+        .current_dir(repo_path)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(normalize_line_endings)
+}
+
+fn list_source_files_from_source(
+    repo_path: &Path,
+    source: &ContentSource,
+) -> Result<Vec<String>, AnalyzeError> {
+    match source {
+        ContentSource::Worktree => list_source_files(repo_path),
+        ContentSource::Index => list_source_files(repo_path),
+        ContentSource::GitRef(refspec) => list_source_files_at_ref(repo_path, refspec),
+    }
 }
 
 /// List all tracked source files in the repo via `git ls-files`.
@@ -703,21 +1059,53 @@ fn list_source_files(repo_path: &Path) -> Result<Vec<String>, AnalyzeError> {
     Ok(files)
 }
 
-fn is_source_file(path: &str) -> bool {
-    let path = path.to_lowercase();
-    path.ends_with(".rs")
-        || path.ends_with(".ts")
-        || path.ends_with(".tsx")
-        || path.ends_with(".js")
-        || path.ends_with(".jsx")
-        || path.ends_with(".py")
-        || path.ends_with(".go")
-        || path.ends_with(".java")
-        || path.ends_with(".c")
-        || path.ends_with(".cpp")
-        || path.ends_with(".rb")
-        || path.ends_with(".cs")
-        || path.ends_with(".php")
+fn list_source_files_at_ref(repo_path: &Path, refspec: &str) -> Result<Vec<String>, AnalyzeError> {
+    let output = std::process::Command::new("git")
+        .args(["ls-tree", "-r", "--name-only", refspec])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| AnalyzeError::Git(format!("failed to run git ls-tree: {}", e)))?;
+
+    if !output.status.success() {
+        return Err(AnalyzeError::Git(format!(
+            "git ls-tree failed for {refspec}"
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let files: Vec<String> = stdout
+        .lines()
+        .filter(|f| !is_noise_file(f))
+        .filter(|f| is_source_file(f))
+        .map(|s| s.to_string())
+        .collect();
+
+    Ok(files)
+}
+
+fn is_source_file(file_path: &str) -> bool {
+    let file_path = file_path.to_lowercase();
+    file_path.ends_with(".rs")
+        || file_path.ends_with(".ts")
+        || file_path.ends_with(".tsx")
+        || file_path.ends_with(".js")
+        || file_path.ends_with(".jsx")
+        || file_path.ends_with(".py")
+        || file_path.ends_with(".go")
+        || file_path.ends_with(".java")
+        || file_path.ends_with(".c")
+        || file_path.ends_with(".cpp")
+        || file_path.ends_with(".rb")
+        || file_path.ends_with(".cs")
+        || file_path.ends_with(".php")
+}
+
+fn normalize_line_endings(s: String) -> String {
+    if s.contains('\r') {
+        s.replace("\r\n", "\n").replace('\r', "\n")
+    } else {
+        s
+    }
 }
 
 fn empty_result() -> ReviewResult {
@@ -789,6 +1177,9 @@ mod tests {
             dependent_names: vec![],
             dependency_names: vec![],
             dependent_entities: vec![],
+            dependency_entities: vec![],
+            before_file_context: None,
+            after_file_context: None,
         }
     }
 
@@ -1280,13 +1671,14 @@ mod tests {
             changes: vec![],
         };
 
-        retain_entity_reviews(&mut result, |review| {
-            review.risk_level >= RiskLevel::High
-        });
+        retain_entity_reviews(&mut result, |review| review.risk_level >= RiskLevel::High);
 
         assert_eq!(result.entity_reviews.len(), 2);
         assert_eq!(result.groups.len(), 2);
-        assert!(result.groups.iter().all(|group| group.entity_ids.len() == 1));
+        assert!(result
+            .groups
+            .iter()
+            .all(|group| group.entity_ids.len() == 1));
         assert_ne!(
             result.entity_reviews[0].group_id,
             result.entity_reviews[1].group_id
@@ -1333,12 +1725,219 @@ mod tests {
         retain_entity_reviews(&mut result, |review| review.entity_id != "main.rs::four");
         assert_eq!(result.dependency_edges.len(), 2);
 
-        retain_entity_reviews(&mut result, |review| {
-            review.risk_level >= RiskLevel::High
-        });
+        retain_entity_reviews(&mut result, |review| review.risk_level >= RiskLevel::High);
 
         assert_eq!(result.entity_reviews.len(), 2);
         assert_eq!(result.groups.len(), 2);
         assert!(result.dependency_edges.is_empty());
+    }
+
+    #[test]
+    fn analyze_with_options_collects_review_prompt_context() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        init_repo(dir);
+
+        std::fs::write(
+            dir.join("main.rs"),
+            r#"fn reject() -> ! {
+    panic!("invalid");
+}
+
+pub fn validate(ok: bool) -> &'static str {
+    if !ok {
+        return "bad";
+    }
+    "ok"
+}
+
+fn consumer() {
+    let _ = validate(true);
+}
+"#,
+        )
+        .unwrap();
+        commit(dir, "init");
+
+        std::fs::write(
+            dir.join("main.rs"),
+            r#"fn reject() -> ! {
+    panic!("invalid");
+}
+
+pub fn validate(ok: bool) -> &'static str {
+    if !ok {
+        reject();
+    }
+    "ok"
+}
+
+fn consumer() {
+    let _ = validate(true);
+}
+"#,
+        )
+        .unwrap();
+        commit(dir, "call reject");
+
+        std::fs::write(
+            dir.join("main.rs"),
+            r#"fn reject() -> ! {
+    panic!("worktree drift");
+}
+
+pub fn validate(ok: bool) -> &'static str {
+    if !ok {
+        reject();
+    }
+    "ok"
+}
+
+fn consumer() {
+    let _ = validate(true);
+}
+"#,
+        )
+        .unwrap();
+
+        let result = analyze_with_options(
+            dir,
+            DiffScope::Commit {
+                sha: "HEAD".to_string(),
+            },
+            &AnalyzeOptions {
+                include_dependent_code: true,
+                include_dependency_code: true,
+                include_file_context: true,
+                file_context_lines: 1,
+                ..AnalyzeOptions::default()
+            },
+        )
+        .unwrap();
+
+        let review = result
+            .entity_reviews
+            .iter()
+            .find(|review| review.entity_name == "validate")
+            .expect("validate should be reviewed");
+
+        assert!(review
+            .dependency_entities
+            .iter()
+            .any(|entity| entity.entity_name == "reject" && entity.content.contains("panic!")));
+        assert!(review
+            .dependency_entities
+            .iter()
+            .all(|entity| !entity.content.contains("worktree drift")));
+        assert!(review
+            .dependent_entities
+            .iter()
+            .any(|entity| entity.entity_name == "consumer"));
+        assert!(review
+            .after_file_context
+            .as_ref()
+            .is_some_and(|context| context.content.contains("validate")));
+    }
+
+    #[test]
+    fn analyze_with_options_collects_before_side_dependency_context() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        init_repo(dir);
+
+        std::fs::write(
+            dir.join("main.rs"),
+            r#"fn reject() -> ! {
+    panic!("invalid");
+}
+
+pub fn validate(ok: bool) -> &'static str {
+    if !ok {
+        reject();
+    }
+    "ok"
+}
+"#,
+        )
+        .unwrap();
+        commit(dir, "init");
+
+        std::fs::write(
+            dir.join("main.rs"),
+            r#"fn reject() -> ! {
+    panic!("invalid");
+}
+
+pub fn validate(ok: bool) -> &'static str {
+    if !ok {
+        return "bad";
+    }
+    "ok"
+}
+"#,
+        )
+        .unwrap();
+        commit(dir, "remove reject call");
+
+        let result = analyze_with_options(
+            dir,
+            DiffScope::Commit {
+                sha: "HEAD".to_string(),
+            },
+            &AnalyzeOptions {
+                include_dependency_code: true,
+                ..AnalyzeOptions::default()
+            },
+        )
+        .unwrap();
+
+        let review = result
+            .entity_reviews
+            .iter()
+            .find(|review| review.entity_name == "validate")
+            .expect("validate should be reviewed");
+
+        assert!(review.dependency_entities.iter().any(|entity| {
+            entity.entity_name == "reject"
+                && entity.relation.as_deref() == Some("before")
+                && entity.content.contains("panic!")
+        }));
+    }
+
+    #[test]
+    fn resolve_before_entity_id_uses_old_name_and_file_for_renames() {
+        let mut entities = HashMap::new();
+        entities.insert(
+            "old-id".to_string(),
+            EntityInfo {
+                id: "old-id".to_string(),
+                name: "validate".to_string(),
+                entity_type: "function".to_string(),
+                file_path: "old.rs".to_string(),
+                parent_id: None,
+                start_line: 1,
+                end_line: 3,
+            },
+        );
+        let graph = EntityGraph::from_parts(entities, vec![]);
+
+        let change: sem_core::model::change::SemanticChange =
+            serde_json::from_value(serde_json::json!({
+                "id": "change-id",
+                "entityId": "new-id",
+                "changeType": "renamed",
+                "entityType": "function",
+                "entityName": "validate_new",
+                "entityLine": 1,
+                "filePath": "new.rs",
+                "oldEntityName": "validate",
+                "oldFilePath": "old.rs"
+            }))
+            .unwrap();
+
+        assert_eq!(
+            resolve_before_entity_id(&change, &graph).as_deref(),
+            Some("old-id")
+        );
     }
 }

--- a/crates/inspect-core/src/llm.rs
+++ b/crates/inspect-core/src/llm.rs
@@ -4,7 +4,7 @@ use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-use crate::types::EntityReview;
+use crate::types::{DependentEntity, EntityReview, SourceContext};
 
 const DEFAULT_MAX_INPUT_TOKENS: u64 = 120_000;
 const DEFAULT_MAX_RETRIES: u32 = 3;
@@ -568,7 +568,7 @@ fn build_prompt(entity: &EntityReview) -> String {
     let mut parts = vec![
         format!("Entity: {} ({})", entity.entity_name, entity.entity_type),
         format!("File: {}", entity.file_path),
-        format!("Change: {:?}", entity.change_type),
+        format!("Change: {}", entity.change_type),
         format!("Classification: {}", entity.classification),
         format!(
             "Risk: {} (score {:.2})",
@@ -577,6 +577,14 @@ fn build_prompt(entity: &EntityReview) -> String {
         format!(
             "Blast radius: {}, Dependents: {}",
             entity.blast_radius, entity.dependent_count
+        ),
+        format!(
+            "Context semantics:\n\
+             - BEFORE and AFTER snippets are complete {} entity bodies, not full-file context.\n\
+             - File context windows are line-numbered excerpts around this entity.\n\
+             - Treat added entities/blocks as additive; omitted surrounding code was not removed unless Change is deleted.\n\
+             - Dependency/helper source shows direct callees referenced by this entity; dependent/caller source shows consumers of this entity.",
+            entity.entity_type
         ),
     ];
 
@@ -594,15 +602,77 @@ fn build_prompt(entity: &EntityReview) -> String {
         parts.push(format!("Dependents:\n{}", deps.join("\n")));
     }
 
+    if !entity.dependency_names.is_empty() {
+        let deps: Vec<String> = entity
+            .dependency_names
+            .iter()
+            .take(10)
+            .map(|(name, file)| format!("  {} ({})", name, file))
+            .collect();
+        parts.push(format!("Dependencies / helpers:\n{}", deps.join("\n")));
+    }
+
+    if let Some(ref context) = entity.before_file_context {
+        parts.push(format_source_context("BEFORE FILE CONTEXT", context));
+    }
+
     if let Some(ref before) = entity.before_content {
         parts.push(format!("BEFORE:\n```\n{}\n```", before));
+    }
+
+    if let Some(ref context) = entity.after_file_context {
+        parts.push(format_source_context("AFTER FILE CONTEXT", context));
     }
 
     if let Some(ref after) = entity.after_content {
         parts.push(format!("AFTER:\n```\n{}\n```", after));
     }
 
+    if !entity.dependency_entities.is_empty() {
+        parts.push(format_related_sources(
+            "DEPENDENCY / HELPER SOURCE",
+            &entity.dependency_entities,
+        ));
+    }
+
+    if !entity.dependent_entities.is_empty() {
+        parts.push(format_related_sources(
+            "DEPENDENT / CALLER SOURCE",
+            &entity.dependent_entities,
+        ));
+    }
+
     parts.join("\n\n")
+}
+
+fn format_source_context(label: &str, context: &SourceContext) -> String {
+    format!(
+        "{} ({}:{}-{}):\n```\n{}\n```",
+        label, context.file_path, context.start_line, context.end_line, context.content
+    )
+}
+
+fn format_related_sources(label: &str, entities: &[DependentEntity]) -> String {
+    entities
+        .iter()
+        .map(|entity| {
+            let relation = entity.relation.as_deref().unwrap_or("current");
+            format!(
+                "{} [{}]: {} {} ({}:{}-{}, public_api={}, dependents={})\n```\n{}\n```",
+                label,
+                relation,
+                entity.entity_type,
+                entity.entity_name,
+                entity.file_path,
+                entity.start_line,
+                entity.end_line,
+                entity.is_public_api,
+                entity.own_dependent_count,
+                entity.content
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
 #[cfg(test)]
@@ -641,6 +711,23 @@ mod tests {
             dependent_names: vec![],
             dependency_names: vec![],
             dependent_entities: vec![],
+            dependency_entities: vec![],
+            before_file_context: None,
+            after_file_context: None,
+        }
+    }
+
+    fn related_entity(name: &str, content: &str) -> DependentEntity {
+        DependentEntity {
+            entity_name: name.to_string(),
+            entity_type: "function".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            start_line: 1,
+            end_line: 3,
+            content: content.to_string(),
+            own_dependent_count: 1,
+            is_public_api: false,
+            relation: Some("after".to_string()),
         }
     }
 
@@ -824,5 +911,49 @@ mod tests {
             body.len(),
             body
         )
+    }
+
+    #[test]
+    fn build_prompt_includes_review_context_sections() {
+        let entity = EntityReview {
+            entity_id: "src/lib.rs::function::validate".to_string(),
+            entity_name: "validate".to_string(),
+            entity_type: "function".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            change_type: ChangeType::Added,
+            classification: ChangeClassification::Functional,
+            risk_score: 0.7,
+            risk_level: RiskLevel::High,
+            blast_radius: 2,
+            dependent_count: 1,
+            dependency_count: 1,
+            is_public_api: true,
+            structural_change: Some(true),
+            group_id: 1,
+            start_line: 10,
+            end_line: 14,
+            before_content: None,
+            after_content: Some("pub fn validate(ok: bool) { reject(); }".to_string()),
+            dependent_names: vec![("caller".to_string(), "src/lib.rs".to_string())],
+            dependency_names: vec![("reject".to_string(), "src/lib.rs".to_string())],
+            dependent_entities: vec![related_entity("caller", "fn caller() { validate(true); }")],
+            dependency_entities: vec![related_entity("reject", "fn reject() -> ! { panic!(); }")],
+            before_file_context: None,
+            after_file_context: Some(SourceContext {
+                file_path: "src/lib.rs".to_string(),
+                start_line: 8,
+                end_line: 16,
+                content: "   8: fn other() {}\n  10: pub fn validate(ok: bool) {".to_string(),
+            }),
+        };
+
+        let prompt = build_prompt(&entity);
+
+        assert!(prompt.contains("Context semantics:"));
+        assert!(prompt.contains("Treat added entities/blocks as additive"));
+        assert!(prompt.contains("Dependencies / helpers:"));
+        assert!(prompt.contains("AFTER FILE CONTEXT"));
+        assert!(prompt.contains("DEPENDENCY / HELPER SOURCE [after]: function reject"));
+        assert!(prompt.contains("DEPENDENT / CALLER SOURCE [after]: function caller"));
     }
 }

--- a/crates/inspect-core/src/predict.rs
+++ b/crates/inspect-core/src/predict.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use sem_core::git::types::DiffScope;
 
-use crate::analyze::{build_context, AnalyzeError};
+use crate::analyze::{build_context, read_file_from_source, AnalyzeError};
 use crate::classify::classify_change;
 use crate::risk::{is_public_api, predict_risk_score, score_to_level};
 use crate::types::*;
@@ -42,7 +42,7 @@ pub fn predict_with_options(
 
     let total_start = Instant::now();
 
-    let ctx = match build_context(repo_path, scope)? {
+    let ctx = match build_context(repo_path, scope, false)? {
         Some(ctx) => ctx,
         None => {
             return Ok(PredictResult {
@@ -95,11 +95,11 @@ pub fn predict_with_options(
                 continue;
             }
 
-            // Read source from the same tree used to build the graph.
-            let file_content = match std::fs::read_to_string(ctx.source_root.join(&dep.file_path)) {
-                Ok(c) => c,
-                Err(_) => continue,
-            };
+            let file_content =
+                match read_file_from_source(repo_path, &ctx.after_source, &dep.file_path) {
+                    Some(c) => c,
+                    None => continue,
+                };
             let lines: Vec<&str> = file_content.lines().collect();
             let start = dep.start_line.saturating_sub(1);
             let end = dep.end_line.min(lines.len());

--- a/crates/inspect-core/src/risk.rs
+++ b/crates/inspect-core/src/risk.rs
@@ -33,7 +33,10 @@ pub fn suggest_verdict(result: &ReviewResult) -> ReviewVerdict {
     }
     // All cosmetic = likely approvable
     let all_cosmetic = !result.entity_reviews.is_empty()
-        && result.entity_reviews.iter().all(|r| r.structural_change == Some(false));
+        && result
+            .entity_reviews
+            .iter()
+            .all(|r| r.structural_change == Some(false));
     if all_cosmetic {
         return ReviewVerdict::LikelyApprovable;
     }
@@ -234,6 +237,9 @@ mod tests {
             dependent_names: vec![],
             dependency_names: vec![],
             dependent_entities: vec![],
+            dependency_entities: vec![],
+            before_file_context: None,
+            after_file_context: None,
         }
     }
 
@@ -242,7 +248,9 @@ mod tests {
         let review = make_review(
             ChangeType::Modified,
             ChangeClassification::Text,
-            0, 0, false,
+            0,
+            0,
+            false,
             Some(false),
         );
         let score = compute_risk_score(&review, 10);
@@ -254,7 +262,9 @@ mod tests {
         let review = make_review(
             ChangeType::Deleted,
             ChangeClassification::Functional,
-            8, 5, true,
+            8,
+            5,
+            true,
             Some(true),
         );
         let score = compute_risk_score(&review, 10);
@@ -267,7 +277,9 @@ mod tests {
         let review = make_review(
             ChangeType::Added,
             ChangeClassification::Functional,
-            0, 0, false,
+            0,
+            0,
+            false,
             None,
         );
         let score = compute_risk_score(&review, 10);
@@ -280,7 +292,9 @@ mod tests {
         let review = make_review(
             ChangeType::Modified,
             ChangeClassification::Functional,
-            0, 0, false,
+            0,
+            0,
+            false,
             Some(true),
         );
         let score = compute_risk_score(&review, 100);
@@ -293,7 +307,9 @@ mod tests {
         let review = make_review(
             ChangeType::Modified,
             ChangeClassification::Functional,
-            5, 8, true,
+            5,
+            8,
+            true,
             Some(true),
         );
         let score = compute_risk_score(&review, 100);

--- a/crates/inspect-core/src/types.rs
+++ b/crates/inspect-core/src/types.rs
@@ -67,6 +67,17 @@ pub struct DependentEntity {
     pub content: String,
     pub own_dependent_count: usize,
     pub is_public_api: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relation: Option<String>,
+}
+
+/// A line-numbered source window around a changed entity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceContext {
+    pub file_path: String,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub content: String,
 }
 
 /// Review information for a single changed entity.
@@ -102,6 +113,16 @@ pub struct EntityReview {
     /// Only populated when analyze_with_options is called with include_dependent_code.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependent_entities: Vec<DependentEntity>,
+    /// Full source code of top dependency entities (callees/helpers).
+    /// Only populated when analyze_with_options is called with include_dependency_code.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependency_entities: Vec<DependentEntity>,
+    /// Surrounding source window from the file before the change.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_file_context: Option<SourceContext>,
+    /// Surrounding source window from the file after the change.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_file_context: Option<SourceContext>,
 }
 
 /// A logical group of related changes (from untangling).

--- a/crates/inspect-core/src/untangle.rs
+++ b/crates/inspect-core/src/untangle.rs
@@ -90,7 +90,10 @@ pub fn untangle(
                 reviews[indices[0]].entity_name.clone()
             } else {
                 // Use common file path prefix or first entity name
-                let files: Vec<&str> = indices.iter().map(|&i| reviews[i].file_path.as_str()).collect();
+                let files: Vec<&str> = indices
+                    .iter()
+                    .map(|&i| reviews[i].file_path.as_str())
+                    .collect();
                 let common = common_prefix(&files);
                 if common.is_empty() {
                     format!("{} entities", entity_ids.len())
@@ -171,6 +174,9 @@ mod tests {
             dependent_names: vec![],
             dependency_names: vec![],
             dependent_entities: vec![],
+            dependency_entities: vec![],
+            before_file_context: None,
+            after_file_context: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- Include selected dependency/helper and dependent/caller source bodies in local inspect review prompts
- Add explicit prompt semantics for before/after entity snippets and line-numbered file context windows
- Build commit/range graphs from the reviewed tree so helper/caller bodies match the target revision
- Include before-side dependency context for removed calls and renamed/moved entities

Closes #15

## Test plan
- cargo test --workspace
- Local inspect review command against a temporary git fixture with a mock OpenAI-compatible server, asserting the outbound prompt contains context semantics, helper source, caller source, and file context